### PR TITLE
Refinement of Workflow Badge Link in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@
    :target: https://img.shields.io/badge/
    :alt: License
 
-.. image:: https://github.com/nathanramoscfa/pycgapi/actions/workflows/main.yml/badge.svg
+.. image:: https://github.com/nathanramoscfa/pycgapi/actions/workflows/tests.yml/badge.svg
    :target: https://github.com/nathanramoscfa/pycgapi/actions/workflows/tests.yml
    :alt: pytest
 


### PR DESCRIPTION
## Overview
This pull request encompasses a single but important change to the documentation, specifically within the `index.rst` file of our project.

## Change Detail
- Updated the badge link in `docs/source/index.rst` to correctly point to the `tests.yml` workflow. This change ensures that the displayed badge accurately reflects the current status of our test workflows.
