### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         run: |
           echo "__version__ = '${{ env.VERSION }}'" > pycgapi/__version__.py
 
+      - name: Install setuptools
+        run: pip install setuptools
+
       - name: Install dependencies
         run: pip install -r requirements.txt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Creation of `__version__.py` to maintain a single source of truth for the project's version number.
 - Updates to README.md and index.rst for correcting hyperlinks to `examples`.
 - Inclusion of `sphinx` in `requirements.txt` for documentation support.
-- Added a change log section to the `README.md` and `index.rst` files.
 
 ### Updated
 - Corrected badge links in `README.md` and `index.rst` to point to the updated `tests.yml` workflow, ensuring accuracy in workflow status representation.
 - Enhanced `conf.py` with additional settings to improve documentation generation.
 - Made specific updates to `docs/source/index.rst` to refine the workflow badge link, maintaining the accuracy and relevance of project documentation.
+- Edited the `README.md` and `index.rst` files to include a change log section.
+
+### Fixed
+- Updated `release.yml` workflow to include a step for installing `setuptools` to fix ModuleNotFoundError.
 
 
 ## [0.1.0] - 2024-01-08


### PR DESCRIPTION
This pull request introduces an update to our GitHub Actions workflow (`release.yml`) by adding a crucial step to install `setuptools`. This addition addresses a recent issue encountered during the automated release process, specifically related to dependency installation failures.

Key Changes:
- **Added Setuptools Installation**: A new step to install `setuptools` has been added before the dependency installation step. This ensures that `distutils`, which is no longer part of the Python standard library in Python 3.12, is available for any packages that require it during the build process.

This change is essential to maintain the smooth functioning of our CI/CD pipeline, particularly in automating the release of new versions to PyPI. By addressing the `distutils` dependency issue, we aim to prevent similar failures in future releases.
